### PR TITLE
Fix docker to docker communication

### DIFF
--- a/roles/ansible-expenses-server/tasks/main.yml
+++ b/roles/ansible-expenses-server/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
-    imap_config:
+    ipam_config:
       - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory

--- a/roles/ansible-expenses-server/tasks/main.yml
+++ b/roles/ansible-expenses-server/tasks/main.yml
@@ -14,6 +14,7 @@
       - database_password is defined
       - dump_day is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - images_service_network_name is defined
       - database_network_name is defined
       - journaling_service_network_name is defined
@@ -23,6 +24,8 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    imap_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory
   file:

--- a/roles/ansible-garments-server/tasks/main.yml
+++ b/roles/ansible-garments-server/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
-    imap_config:
+    ipam_config:
       - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory

--- a/roles/ansible-garments-server/tasks/main.yml
+++ b/roles/ansible-garments-server/tasks/main.yml
@@ -15,6 +15,7 @@
       - dump_day is defined
       - host_port is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - images_service_network_name is defined
       - user_info_service_network_name is defined
       - database_network_name is defined
@@ -24,6 +25,8 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    imap_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory
   file:

--- a/roles/ansible-iptables/tasks/main.yml
+++ b/roles/ansible-iptables/tasks/main.yml
@@ -18,7 +18,7 @@
     chain: DOCKER-USER
     protocol: tcp
     in_interface: eth0
-    source: '!172.16.0.0/12'
+    source: '172.16.0.0/12'
     jump: RETURN
 
 # TODO: This could be more configurable

--- a/roles/ansible-iptables/tasks/main.yml
+++ b/roles/ansible-iptables/tasks/main.yml
@@ -12,6 +12,15 @@
   loop:
     - 'iptables-persistent'
 
+- name: "Allow docker to docker communication"
+  ansible.builtin.iptables:
+    action: "insert"
+    chain: DOCKER-USER
+    protocol: tcp
+    in_interface: eth0
+    source: '!172.16.0.0/12'
+    jump: RETURN
+
 # TODO: This could be more configurable
 - name: "Allow node exporter port for VPN addresses only"
   ansible.builtin.iptables:

--- a/roles/ansible-iptables/tasks/main.yml
+++ b/roles/ansible-iptables/tasks/main.yml
@@ -17,7 +17,6 @@
     action: "insert"
     chain: DOCKER-USER
     protocol: tcp
-    in_interface: eth0
     source: '172.16.0.0/12'
     jump: RETURN
 

--- a/roles/ansible-itemtree-server/tasks/main.yml
+++ b/roles/ansible-itemtree-server/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
-    imap_config:
+    ipam_config:
       - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory

--- a/roles/ansible-itemtree-server/tasks/main.yml
+++ b/roles/ansible-itemtree-server/tasks/main.yml
@@ -14,6 +14,7 @@
       - database_password is defined
       - dump_day is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - host_port is defined
       - images_service_network_name is defined
       - user_info_service_network_name is defined
@@ -24,6 +25,8 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    imap_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory
   file:

--- a/roles/ansible-nextcloud/tasks/main.yml
+++ b/roles/ansible-nextcloud/tasks/main.yml
@@ -4,6 +4,7 @@
     that:
       - application_name is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - host_port is defined
       - loki_url is defined
       - dump_day is defined
@@ -24,6 +25,8 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    ipam_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the nextcloud data volumne
   community.docker.docker_volume:

--- a/roles/ansible-plants-server/tasks/main.yml
+++ b/roles/ansible-plants-server/tasks/main.yml
@@ -16,6 +16,7 @@
       - database_password is defined
       - dump_day is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - images_service_network_name is defined
       - user_info_service_network_name is defined
       - database_network_name is defined
@@ -25,6 +26,8 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    imap_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory
   file:

--- a/roles/ansible-plants-server/tasks/main.yml
+++ b/roles/ansible-plants-server/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
-    imap_config:
+    ipam_config:
       - subnet: "{{ docker_network_subnet }}"
 
 - name: Create the files directory

--- a/roles/ansible-user-info-service/tasks/main.yml
+++ b/roles/ansible-user-info-service/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
-    imap_config:
+    ipam_config:
       - subnet: "{{ docker_network_subnet }}"
 
 - name: Create app container

--- a/roles/ansible-user-info-service/tasks/main.yml
+++ b/roles/ansible-user-info-service/tasks/main.yml
@@ -10,12 +10,15 @@
       - database_user is defined
       - database_password is defined
       - docker_network_name is defined
+      - docker_network_subnet is defined
       - database_network_name is defined
       - dump_day is defined
 
 - name: Create the dockernetwork
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+    imap_config:
+      - subnet: "{{ docker_network_subnet }}"
 
 - name: Create app container
   community.docker.docker_container:


### PR DESCRIPTION
Fixes docker to docker communication within the hosts by adding a iptables rule, it also allows manually setting subnets for those networks that were assigned by IPAM to subnets out of the desired range, as this is apparently non-deterministic all subnets should be manually specified to always be within the range, but I don't have time for that now.
